### PR TITLE
extend setOutputRange function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(LMS1xx_node src/LMS1xx_node.cpp)
 target_link_libraries(LMS1xx_node LMS1xx ${catkin_LIBRARIES})
 
+add_executable(LMS1xx_configuration src/LMS1xx_configuration.cpp)
+target_link_libraries(LMS1xx_configuration LMS1xx ${catkin_LIBRARIES})
 
-install(TARGETS LMS1xx LMS1xx_node
+install(TARGETS LMS1xx LMS1xx_node LMS1xx_configuration
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/include/LMS1xx/LMS1xx.h
+++ b/include/LMS1xx/LMS1xx.h
@@ -294,6 +294,16 @@ public:
 	void setScanDataCfg(const scanDataCfg &cfg);
 
 	/*!
+	* @brief Set output range configuration.
+	* Get output range configuration :
+	* - angle resolution.
+	* - start angle.
+	* - stop angle.
+	* @param cfg structure containing output range configuration.
+	*/
+	void setOutputRange(const scanOutputRange &cfg);
+
+	/*!
 	* @brief Get current output range configuration.
 	* Get output range configuration :
 	* - scanning resolution.

--- a/launch/LMS1xx_configuration.launch
+++ b/launch/LMS1xx_configuration.launch
@@ -1,0 +1,21 @@
+<launch>
+  <arg name="host"                  default="192.168.1.14" />
+  <arg name="time_out"              default="10" />
+
+  <!-- SICK new configuration to set -->
+  <arg name="scaning_frequency"     default="5000" />
+  <arg name="angle_resolution"      default="5000" />
+  <arg name="start_angle"           default="-450000" />
+  <arg name="stop_angle"            default="2250000" />
+  <arg name="make_persistent"       default="false" />
+
+  <node pkg="lms1xx" name="lms1xx" type="LMS1xx_configuration" output="screen">
+    <param name="host"              value="$(arg host)" />
+    <param name="time_out"          value="$(arg time_out)" />
+    <param name="scaning_frequency" value="$(arg scaning_frequency)" />
+    <param name="angle_resolution"  value="$(arg angle_resolution)" />
+    <param name="start_angle"       value="$(arg start_angle)" />
+    <param name="stop_angle"        value="$(arg stop_angle)" />
+    <param name="make_persistent"   value="$(arg make_persistent)" />
+  </node>
+</launch>

--- a/src/LMS1xx.cpp
+++ b/src/LMS1xx.cpp
@@ -187,6 +187,18 @@ void LMS1xx::setScanDataCfg(const scanDataCfg &cfg) {
 	buf[len - 1] = 0;
 }
 
+void LMS1xx::setOutputRange(const scanOutputRange &cfg) {
+	char buf[100];
+	sprintf(buf, "%c%s 1 %X %X %X%c", 0x02, "sWN LMPoutputRange",
+			cfg.angleResolution, cfg.startAngle, cfg.stopAngle, 0x03);
+
+	write(sockDesc, buf, strlen(buf));
+
+	int len = read(sockDesc, buf, 100);
+
+	buf[len - 1] = 0;
+}
+
 scanOutputRange LMS1xx::getScanOutputRange() const {
 	scanOutputRange outputRange;
 	char buf[100];

--- a/src/LMS1xx_configuration.cpp
+++ b/src/LMS1xx_configuration.cpp
@@ -1,0 +1,82 @@
+#include <csignal>
+#include <cstdio>
+#include <LMS1xx/LMS1xx.h>
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+
+#define DEG2RAD M_PI/180.0
+
+int main(int argc, char **argv)
+{
+  // laser data
+  LMS1xx laser;
+  scanCfg scan_config;
+  scanOutputRange output_config;
+
+  // parameters
+  std::string host;
+  std::string frame_id;
+
+  const std::string& node_name = "lms1xx_configuration";
+  ros::init(argc, argv, node_name);
+  ros::NodeHandle n("~");
+
+  n.param<std::string>("host", host, "192.168.1.2");
+  int time = 10;
+  n.param<int>("time_out", time, time);
+
+  ros::Duration time_out(time);
+  ros::Time starting_time = ros::Time::now();
+
+  // reading current SICK configuration
+  while(!laser.isConnected()) {
+    ros::Duration d(ros::Time::now()-starting_time);
+    if (d>time_out)
+    {
+      ROS_ERROR_STREAM_NAMED(node_name, "Time out while trying to connect to laser " << host);
+      exit(-1);
+    }
+
+    laser.connect(host);
+    if(laser.isConnected())
+    {
+      laser.scanContinous(0);
+      laser.stopMeas();
+      laser.login();
+      scan_config = laser.getScanCfg();
+    }
+    ROS_INFO_STREAM_NAMED(node_name, "Waiting for laser to connect!");
+  }
+
+  // read new configuration from param server
+  n.param<int>("scaning_frequency",  scan_config.scaningFrequency, scan_config.scaningFrequency);
+  n.param<int>("angle_resolution",   scan_config.angleResolution,  scan_config.angleResolution);
+  n.param<int>("start_angle",        scan_config.startAngle,       scan_config.startAngle);
+  n.param<int>("stop_angle",         scan_config.stopAngle,        scan_config.stopAngle);
+  bool make_persistent = false;
+  n.param<bool>("make_persistent",   make_persistent,              make_persistent);
+
+  output_config.angleResolution = scan_config.angleResolution;
+  output_config.startAngle      = scan_config.startAngle;
+  output_config.stopAngle       = scan_config.stopAngle;
+
+  laser.setScanCfg(scan_config);
+  laser.setOutputRange(output_config);
+  if (make_persistent)
+  {
+    laser.saveConfig(); // make permanently
+  }
+
+  scan_config = laser.getScanCfg();
+  output_config = laser.getScanOutputRange();
+
+  ROS_INFO("New laser configuration: scaningFrequency %d, angleResolution %d, startAngle %d, stopAngle %d",
+                scan_config.scaningFrequency, scan_config.angleResolution, scan_config.startAngle, scan_config.stopAngle);
+  ROS_INFO("New laser output range:angleResolution %d, startAngle %d, stopAngle %d",
+                output_config.angleResolution, output_config.startAngle, output_config.stopAngle);
+
+  ROS_INFO_STREAM_NAMED(node_name, "Shutting down laser " << host);
+  laser.disconnect();
+
+  return 0;
+}

--- a/src/LMS1xx_node.cpp
+++ b/src/LMS1xx_node.cpp
@@ -47,12 +47,12 @@ int main(int argc, char **argv)
 
       //check if laser is fully initialized, else reconnect
       //assuming fully initialized => scaningFrequency=5000
-      if (cfg.scaningFrequency != 5000) {
-	laser.disconnect();
-	ROS_INFO("Waiting for laser to initialize...");
-      }
+      //if (cfg.scaningFrequency != 5000) {
+	//laser.disconnect();
+	//ROS_INFO("Waiting for laser to initialize...");
+      //}
 
-    } while (!laser.isConnected() || cfg.scaningFrequency != 5000);
+    } while (!laser.isConnected());
 
     if (laser.isConnected()) {
       ROS_INFO("Connected to laser.");


### PR DESCRIPTION
According to [SICK's developer guide](https://www.sick.com/media/pdf/7/27/927/IM0045927.PDF) we have to trigger 2 functions to fully configure the laser. 
The `LMS1xx::setScanCfg` [LMS1.xx#L287](https://github.com/clearpathrobotics/LMS1xx/blob/master/include/LMS1xx/LMS1xx.h#L287) function alone does not sufficiently set the output range parameters. Hence the extension in this PR.