### PR TITLE
Variable scan frequence

### DIFF
--- a/include/LMS1xx/LMS1xx.h
+++ b/include/LMS1xx/LMS1xx.h
@@ -294,6 +294,16 @@ public:
 	void setScanDataCfg(const scanDataCfg &cfg);
 
 	/*!
+	* @brief Set output range configuration.
+	* Get output range configuration :
+	* - angle resolution.
+	* - start angle.
+	* - stop angle.
+	* @param cfg structure containing output range configuration.
+	*/
+	void setOutputRange(const scanOutputRange &cfg);
+
+	/*!
 	* @brief Get current output range configuration.
 	* Get output range configuration :
 	* - scanning resolution.

--- a/src/LMS1xx.cpp
+++ b/src/LMS1xx.cpp
@@ -187,6 +187,18 @@ void LMS1xx::setScanDataCfg(const scanDataCfg &cfg) {
 	buf[len - 1] = 0;
 }
 
+void LMS1xx::setOutputRange(const scanOutputRange &cfg) {
+	char buf[100];
+	sprintf(buf, "%c%s 1 %X %X %X%c", 0x02, "sWN LMPoutputRange",
+			cfg.angleResolution, cfg.startAngle, cfg.stopAngle, 0x03);
+
+	write(sockDesc, buf, strlen(buf));
+
+	int len = read(sockDesc, buf, 100);
+
+	buf[len - 1] = 0;
+}
+
 scanOutputRange LMS1xx::getScanOutputRange() const {
 	scanOutputRange outputRange;
 	char buf[100];

--- a/src/LMS1xx_node.cpp
+++ b/src/LMS1xx_node.cpp
@@ -45,14 +45,9 @@ int main(int argc, char **argv)
 	outputRange = laser.getScanOutputRange();
       }
 
-      //check if laser is fully initialized, else reconnect
-      //assuming fully initialized => scaningFrequency=5000
-      if (cfg.scaningFrequency != 5000) {
-	laser.disconnect();
 	ROS_INFO("Waiting for laser to initialize...");
-      }
 
-    } while (!laser.isConnected() || cfg.scaningFrequency != 5000);
+    } while (!laser.isConnected());
 
     if (laser.isConnected()) {
       ROS_INFO("Connected to laser.");


### PR DESCRIPTION
According to [SICK's developer guide](https://www.sick.com/media/pdf/7/27/927/IM0045927.PDF) we have to trigger 2 functions to fully configure the laser. 
The `LMS1xx::setScanCfg` [LMS1.xx#L287](https://github.com/clearpathrobotics/LMS1xx/blob/master/include/LMS1xx/LMS1xx.h#L287) function alone does not sufficiently set the output range parameters. Hence the extension in this PR.