### PR TITLE
add parameters 'sample_size' and 'update_rate' for gazebo's ray plugin

### DIFF
--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="sick_lms1xx" params="frame:=laser topic:=scan" >
+  <xacro:macro name="sick_lms1xx" params="frame:=laser topic:=scan sample_size:=720 update_rate:=50" >
     <link name="${frame}">
       <inertial>
         <mass value="1.1" />
@@ -58,11 +58,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <sensor type="ray" name="${frame}">
         <pose>0 0 0 0 0 0</pose>
         <visualize>false</visualize>
-        <update_rate>50</update_rate>
+        <update_rate>${update_rate}</update_rate>
         <ray>
           <scan>
             <horizontal>
-              <samples>720</samples>
+              <samples>${sample_size}</samples>
               <resolution>1</resolution>
               <min_angle>-2.35619</min_angle>
               <max_angle>2.35619</max_angle>


### PR DESCRIPTION
Allows the user to set the `update_rate` and `sample_size` parameters in the urdf, to make gazebo less cpu intensive