### PR TITLE
add clock synchronization feature (NTP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(LMS1xx_node src/LMS1xx_node.cpp)
 target_link_libraries(LMS1xx_node LMS1xx ${catkin_LIBRARIES})
 
+add_executable(LMS1xx_NTP_diagnostic src/LMS1xx_NTP_diagnostic.cpp)
+target_link_libraries(LMS1xx_NTP_diagnostic LMS1xx ${catkin_LIBRARIES})
 
-install(TARGETS LMS1xx LMS1xx_node
+install(TARGETS LMS1xx LMS1xx_node LMS1xx_NTP_diagnostic
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/include/LMS1xx/LMS1xx.h
+++ b/include/LMS1xx/LMS1xx.h
@@ -62,6 +62,15 @@ public:
   void connect(std::string host, int port = 2111);
 
   /*!
+  * @brief get max time offset and delay.
+  */
+  NTPstatus getNTPstatus() const;
+  
+  /*!
+  * @brief set NTP settings.
+  */
+  void setNTPsettings(const NTPcfg &cfg);
+  /*!
   * @brief Disconnect from LMS1xx device.
   */
   void disconnect();

--- a/include/LMS1xx/lms_structs.h
+++ b/include/LMS1xx/lms_structs.h
@@ -60,6 +60,67 @@ struct scanCfg
 };
 
 /*!
+* @class NTProleCfg
+* @brief Structure containing NTP role configuration.
+*
+* @author Wojciech Dudek
+*/
+
+struct NTPcfg
+{
+  /*!
+   * @brief NTP role.
+   * None: 0
+   * Client: 1
+   * Server: 2
+   */
+  int NTProle;
+  /*!
+   * @brief Time synchronization interface.
+   * Ethernet: 0
+   * CAN: 1
+   */
+  int timeSyncIfc;
+  /*!
+   * @brief Time server IP address.
+   * [0].[1].[2].[3]
+   */
+  int serverIP[4];
+  /*!
+   * @brief Time zone.
+   * Set values in number of hours relative to GMT, hex specially coded
+   * [GMT + …] -12d … +12d (00h … 18h)
+   */
+  int timeZone;
+  /*!
+   * @brief Update time.
+   * Set values in seconds
+   */
+  int updateTime;
+};
+
+/*!
+* @class NTProleCfg
+* @brief Structure containing NTP status.
+*
+* @author Wojciech Dudek
+*/
+
+struct NTPstatus
+{
+  /*!
+   * @brief Read maximum offset time.
+   * [Seconds as float according to IEEE754]
+   */
+  float maxOffsetNTP;
+  /*!
+   * @brief Delay time.
+   * [Seconds as float according to IEEE754]
+   */
+  float timeDelay;
+};
+
+/*!
 * @class scanDataCfg
 * @brief Structure containing scan data configuration.
 *
@@ -201,6 +262,24 @@ struct scanData
    *
    */
   uint16_t rssi2[1082];
+
+  /*!
+   * @brief Time stamp of the msg - seconds
+   *
+   */
+  time_t msg_sec;
+
+  /*!
+   * @brief Time stamp of the msg - micro seconds
+   *
+   */
+  uint32_t msg_usec;
+
+  /*!
+   * @brief Time since start up - micro seconds
+   *
+   */
+  uint32_t msg_startup_usec;
 };
 
 #endif  // LMS1XX_LMS_STRUCTS_H_

--- a/launch/LMS1xx.launch
+++ b/launch/LMS1xx.launch
@@ -1,6 +1,19 @@
 <launch>
   <arg name="host" default="192.168.1.14" />
-  <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
-    <param name="host" value="$(arg host)" />
-  </node>
+  <arg name="useNTP" default="false" />
+  <arg name="NTProle" default="1" />
+  <arg name="timeSyncIfc" default="0" />
+  <arg name="serverIP" default="192.168.1.1" />
+  <arg name="timeZone" default="1" />
+  <arg name="updateTime" default="40" />
+
+    <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
+       <param name="host" value="$(arg host)" />
+       <param name="useNTP" value="$(arg useNTP)" />
+       <param name="NTProle" value="$(arg NTProle)" />
+       <param name="timeSyncIfc" value="$(arg timeSyncIfc)" />
+       <param name="serverIP" value="$(arg serverIP)" />
+       <param name="timeZone" value="$(arg timeZone)" />
+       <param name="updateTime" value="$(arg updateTime)" />
+    </node>
 </launch>

--- a/src/LMS1xx_NTP_diagnostic.cpp
+++ b/src/LMS1xx_NTP_diagnostic.cpp
@@ -1,0 +1,60 @@
+/*
+ *  LMS1xx_NTP_diagnostic.cpp
+ *
+ *  Created on: 24-01-2017
+ *  Author: Wojciech Dudek
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <LMS1xx/LMS1xx.h>
+#include "console_bridge/console.h"
+#include <stdlib.h> 
+
+int main(int argc, char** argv){
+
+	LMS1xx laser;
+	NTPstatus ntp_status;
+	scanCfg cfg;
+	scanOutputRange outputRange;
+	std::string host = "192.168.0.20";
+	console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
+
+	if (argc == 2){
+		host = argv[1];
+	}else{
+		logWarn("\nUsage: LMS1xx_NTP_diagnostic <HOST_IP> \nUsing default: %s",host.c_str());
+	} 
+
+	laser.connect(host);
+	while (!laser.isConnected()){
+  		logWarn("Unable to connect, retrying.");
+      	sleep(1);
+      	continue;
+	} 
+    // get NTP stats
+    ntp_status = laser.getNTPstatus();
+    // get scan params
+    cfg = laser.getScanCfg();
+    outputRange = laser.getScanOutputRange();
+    logInform("Laser configuration: scaningFrequency %d, angleResolution %d, startAngle %d, stopAngle %d",
+              cfg.scaningFrequency, cfg.angleResolution, cfg.startAngle, cfg.stopAngle);
+    logInform("Laser output range: angleResolution %d, startAngle %d, stopAngle %d",
+              outputRange.angleResolution, outputRange.startAngle, outputRange.stopAngle);
+    logInform("Max NTP offset: %f", ntp_status.maxOffsetNTP);
+    logInform("NTP time delay: %f", ntp_status.timeDelay);
+}


### PR DESCRIPTION
Laser scanner (LMS100) is capable of clock synchronization (using Network Time Protocol). This PR:

1.  adds clock synchronization to the LMS1xx library. 
    - Scan data structure returns:
       - time stamp of the msg - seconds,
       - time stamp of the msg - micro seconds,
       - time since laser scanner start up - micro seconds
    - An additional configuration method is implemented.
2.  adds configuration parameters to the launch file,
3.  adds the `LMS1xx_NTP_diagnostic` node to print current state of the laser scanner,
4.  modifies the `LMS1xx_node` node to handle the NTP clock synchronization (if the `useNTP` param is set true) 