### PR TITLE
Fixed warning about inconsistent namespace redefinitions for xmlns:xacro.

### DIFF
--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -27,7 +27,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="sick_lms1xx" params="frame:=laser topic:=scan sample_size:=720 update_rate:=50
                min_angle:=-2.35619 max_angle:=2.35619 min_range:=0.1 max_range:=30.0 robot_namespace:=/" >


### PR DESCRIPTION
Minor syntax change in xacro caused warnings.