### PR TITLE
Replace deprecated log macros

### DIFF
--- a/include/LMS1xx/lms_buffer.h
+++ b/include/LMS1xx/lms_buffer.h
@@ -46,12 +46,12 @@ public:
     if (ret > 0)
     {
       total_length_ += ret;
-      logDebug("Read %d bytes from fd, total length is %d.", ret, total_length_);
+      CONSOLE_BRIDGE_logDebug("Read %d bytes from fd, total length is %d.", ret, total_length_);
     }
     else
     {
 
-      logWarn("Buffer read() returned error.");
+      CONSOLE_BRIDGE_logWarn("Buffer read() returned error.");
     }
   }
 
@@ -60,7 +60,7 @@ public:
     if (total_length_ == 0)
     {
       // Buffer is empty, no scan data present.
-      logDebug("Empty buffer, nothing to return.");
+      CONSOLE_BRIDGE_logDebug("Empty buffer, nothing to return.");
       return NULL;
     }
 
@@ -71,13 +71,13 @@ public:
     if (start_of_message == NULL)
     {
       // None found, buffer reset.
-      logWarn("No STX found, dropping %d bytes from buffer.", total_length_);
+      CONSOLE_BRIDGE_logWarn("No STX found, dropping %d bytes from buffer.", total_length_);
       total_length_ = 0;
     }
     else if (buffer_ != start_of_message)
     {
       // Start of message found, ahead of the start of buffer. Therefore shift the buffer back.
-      logWarn("Shifting buffer, dropping %d bytes, %d bytes remain.",
+      CONSOLE_BRIDGE_logWarn("Shifting buffer, dropping %d bytes, %d bytes remain.",
               (start_of_message - buffer_), total_length_ - (start_of_message - buffer_));
       shiftBuffer(start_of_message);
     }
@@ -87,7 +87,7 @@ public:
     if (end_of_first_message_ == NULL)
     {
       // No end of message found, therefore no message to parse and return.
-      logDebug("No ETX found, nothing to return.");
+      CONSOLE_BRIDGE_logDebug("No ETX found, nothing to return.");
       return NULL;
     }
 

--- a/src/LMS1xx.cpp
+++ b/src/LMS1xx.cpp
@@ -48,7 +48,7 @@ void LMS1xx::connect(std::string host, int port)
 {
   if (!connected_)
   {
-    logDebug("Creating non-blocking socket.");
+    CONSOLE_BRIDGE_logDebug("Creating non-blocking socket.");
     socket_fd_ = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (socket_fd_)
     {
@@ -57,13 +57,13 @@ void LMS1xx::connect(std::string host, int port)
       stSockAddr.sin_port = htons(port);
       inet_pton(AF_INET, host.c_str(), &stSockAddr.sin_addr);
 
-      logDebug("Connecting socket to laser.");
+      CONSOLE_BRIDGE_logDebug("Connecting socket to laser.");
       int ret = ::connect(socket_fd_, (struct sockaddr *) &stSockAddr, sizeof(stSockAddr));
 
       if (ret == 0)
       {
         connected_ = true;
-        logDebug("Connected succeeded.");
+        CONSOLE_BRIDGE_logDebug("Connected succeeded.");
       }
     }
   }
@@ -92,9 +92,9 @@ void LMS1xx::startMeas()
 
   int len = read(socket_fd_, buf, 100);
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }
 
 void LMS1xx::stopMeas()
@@ -106,9 +106,9 @@ void LMS1xx::stopMeas()
 
   int len = read(socket_fd_, buf, 100);
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }
 
 status_t LMS1xx::queryStatus()
@@ -120,9 +120,9 @@ status_t LMS1xx::queryStatus()
 
   int len = read(socket_fd_, buf, 100);
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 
   int ret;
   sscanf((buf + 10), "%d", &ret);
@@ -156,9 +156,9 @@ void LMS1xx::login()
 
   int len = read(socket_fd_, buf, 100);
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }
 
 scanCfg LMS1xx::getScanCfg() const
@@ -171,9 +171,9 @@ scanCfg LMS1xx::getScanCfg() const
 
   int len = read(socket_fd_, buf, 100);
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 
   sscanf(buf + 1, "%*s %*s %X %*d %X %X %X", &cfg.scaningFrequency,
          &cfg.angleResolution, &cfg.startAngle, &cfg.stopAngle);
@@ -201,7 +201,7 @@ void LMS1xx::setScanDataCfg(const scanDataCfg &cfg)
           "sWN LMDscandatacfg", cfg.outputChannel, cfg.remission ? 1 : 0,
           cfg.resolution, cfg.encoder, cfg.position ? 1 : 0,
           cfg.deviceName ? 1 : 0, cfg.timestamp ? 1 : 0, cfg.outputInterval, 0x03);
-  logDebug("TX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("TX: %s", buf);
   write(socket_fd_, buf, strlen(buf));
 
   int len = read(socket_fd_, buf, 100);
@@ -233,10 +233,10 @@ void LMS1xx::scanContinous(int start)
   int len = read(socket_fd_, buf, 100);
 
   if (buf[0] != 0x02)
-    logError("invalid packet recieved");
+    CONSOLE_BRIDGE_logError("invalid packet recieved");
 
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }
 
 bool LMS1xx::getScanData(scanData* scan_data)
@@ -254,9 +254,9 @@ bool LMS1xx::getScanData(scanData* scan_data)
     tv.tv_sec = 0;
     tv.tv_usec = 100000;
 
-    logDebug("entering select()", tv.tv_usec);
+    CONSOLE_BRIDGE_logDebug("entering select()", tv.tv_usec);
     int retval = select(socket_fd_ + 1, &rfds, NULL, NULL, &tv);
-    logDebug("returned %d from select()", retval);
+    CONSOLE_BRIDGE_logDebug("returned %d from select()", retval);
     if (retval)
     {
       buffer_.readFrom(socket_fd_);
@@ -313,7 +313,7 @@ void LMS1xx::parseScanData(char* buffer, scanData* data)
   tok = strtok(NULL, " "); //NumberChannels16Bit
   int NumberChannels16Bit;
   sscanf(tok, "%d", &NumberChannels16Bit);
-  logDebug("NumberChannels16Bit : %d", NumberChannels16Bit);
+  CONSOLE_BRIDGE_logDebug("NumberChannels16Bit : %d", NumberChannels16Bit);
 
   for (int i = 0; i < NumberChannels16Bit; i++)
   {
@@ -344,7 +344,7 @@ void LMS1xx::parseScanData(char* buffer, scanData* data)
     tok = strtok(NULL, " "); //NumberData
     int NumberData;
     sscanf(tok, "%X", &NumberData);
-    logDebug("NumberData : %d", NumberData);
+    CONSOLE_BRIDGE_logDebug("NumberData : %d", NumberData);
 
     if (type == 0)
     {
@@ -392,7 +392,7 @@ void LMS1xx::parseScanData(char* buffer, scanData* data)
   tok = strtok(NULL, " "); //NumberChannels8Bit
   int NumberChannels8Bit;
   sscanf(tok, "%d", &NumberChannels8Bit);
-  logDebug("NumberChannels8Bit : %d\n", NumberChannels8Bit);
+  CONSOLE_BRIDGE_logDebug("NumberChannels8Bit : %d\n", NumberChannels8Bit);
 
   for (int i = 0; i < NumberChannels8Bit; i++)
   {
@@ -423,7 +423,7 @@ void LMS1xx::parseScanData(char* buffer, scanData* data)
     tok = strtok(NULL, " "); //NumberData
     int NumberData;
     sscanf(tok, "%X", &NumberData);
-    logDebug("NumberData : %d\n", NumberData);
+    CONSOLE_BRIDGE_logDebug("NumberData : %d\n", NumberData);
 
     if (type == 0)
     {
@@ -477,9 +477,9 @@ void LMS1xx::saveConfig()
   int len = read(socket_fd_, buf, 100);
 
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }
 
 void LMS1xx::startDevice()
@@ -492,7 +492,7 @@ void LMS1xx::startDevice()
   int len = read(socket_fd_, buf, 100);
 
   if (buf[0] != 0x02)
-    logWarn("invalid packet recieved");
+    CONSOLE_BRIDGE_logWarn("invalid packet recieved");
   buf[len] = 0;
-  logDebug("RX: %s", buf);
+  CONSOLE_BRIDGE_logDebug("RX: %s", buf);
 }


### PR DESCRIPTION
I believe the deprecated macros have been removed in Melodic, so this patch fixes compile errors.
Note, this breaks compatibility with Indigo, but still compiles for Kinetic onward.