### PR TITLE
Implemented a nodelet version of the driver.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,26 @@ add_library(LMS1xx src/LMS1xx.cpp)
 target_link_libraries(LMS1xx ${console_bridge_LIBRARIES})
 
 # Regular catkin package follows.
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs)
-catkin_package(CATKIN_DEPENDS roscpp)
+find_package(catkin REQUIRED COMPONENTS nodelet roscpp sensor_msgs)
+catkin_package(CATKIN_DEPENDS nodelet roscpp)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(LMS1xx_node src/LMS1xx_node.cpp)
 target_link_libraries(LMS1xx_node LMS1xx ${catkin_LIBRARIES})
+add_library(LMS1xx_nodelet src/LMS1xx_nodelet.cpp)
+target_link_libraries(LMS1xx_nodelet LMS1xx ${catkin_LIBRARIES})
 
 
-install(TARGETS LMS1xx LMS1xx_node
+install(TARGETS LMS1xx LMS1xx_node LMS1xx_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 install(DIRECTORY meshes launch urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(FILES nodelets.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(PROGRAMS scripts/find_sick scripts/set_sick_ip

--- a/include/LMS1xx/lms_buffer.h
+++ b/include/LMS1xx/lms_buffer.h
@@ -32,6 +32,11 @@
 #define LMS_STX 0x02
 #define LMS_ETX 0x03
 
+#define logWarn CONSOLE_BRIDGE_logWarn
+#define logError CONSOLE_BRIDGE_logError
+#define logDebug CONSOLE_BRIDGE_logDebug
+#define logInform CONSOLE_BRIDGE_logInform
+
 class LMSBuffer
 {
 public:

--- a/launch/LMS1xx.launch
+++ b/launch/LMS1xx.launch
@@ -1,7 +1,12 @@
 <launch>
   <arg name="host" default="192.168.1.14" />
   <arg name="publish_min_range_as_inf" default="false" />
-  <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
+  <arg name="nodelet_manager" default="" />
+  <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node" if="$(eval nodelet_manager=='')">
+    <param name="host" value="$(arg host)" />
+    <param name="publish_min_range_as_inf" value="$(arg publish_min_range_as_inf)" />
+  </node>
+  <node pkg="nodelet" name="lms1xx" type="nodelet" args="load lms1xx/LMS1xx_nodelet $(arg nodelet_manager)" if="$(eval nodelet_manager!='')">
     <param name="host" value="$(arg host)" />
     <param name="publish_min_range_as_inf" value="$(arg publish_min_range_as_inf)" />
   </node>

--- a/nodelets.xml
+++ b/nodelets.xml
@@ -1,0 +1,7 @@
+<library path="lib/libLMS1xx_nodelet">
+  <class name="lms1xx/LMS1xx_nodelet" type="lms1xx::LMS1xxNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet version of LMS1xx driver.
+    </description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <license>LGPL</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>nodelet</depend>
   <depend>rosconsole_bridge</depend>
   <depend>roscpp</depend>
   <depend>roscpp_serialization</depend>
@@ -19,4 +20,8 @@
   <test_depend>roslaunch</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rosunit</test_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelets.xml" />
+  </export>
 </package>

--- a/src/LMS1xx_nodelet.cpp
+++ b/src/LMS1xx_nodelet.cpp
@@ -1,0 +1,227 @@
+#include <string>
+#include <thread>
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <LMS1xx/LMS1xx.h>
+#include <sensor_msgs/LaserScan.h>
+
+#include <pluginlib/class_list_macros.h>
+
+#define DEG2RAD M_PI/180.0
+
+namespace lms1xx {
+
+class LMS1xxNodelet : public nodelet::Nodelet {
+
+public:
+  virtual ~LMS1xxNodelet();
+
+protected:
+  void onInit() override;
+  void loop();
+
+  std::thread thread;
+
+  LMS1xx laser;
+  scanCfg cfg;
+  scanOutputRange outputRange;
+  scanDataCfg dataCfg;
+  ros::Publisher scan_pub;
+
+  // parameters
+  std::string host;
+  std::string frame_id;
+  bool inf_range;
+  int port;
+
+  ros::NodeHandle nh, n;
+
+  volatile bool isShuttingDown = false;
+
+  bool ok() const {
+    return !isShuttingDown && ros::ok();
+  }
+};
+
+
+void LMS1xxNodelet::onInit() {
+  nh = getNodeHandle();
+  n = getPrivateNodeHandle();
+
+  n.param<std::string>("host", host, "192.168.1.2");
+  n.param<std::string>("frame_id", frame_id, "laser");
+  n.param<bool>("publish_min_range_as_inf", inf_range, false);
+  n.param<int>("port", port, 2111);
+
+  scan_pub = nh.advertise<sensor_msgs::LaserScan>("scan", 1);
+
+  thread = std::thread(&LMS1xxNodelet::loop, this);
+}
+
+void LMS1xxNodelet::loop() {
+  while (this->ok()) {
+    NODELET_INFO_STREAM("Connecting to laser at " << host);
+    laser.connect(host, port);
+    if (!laser.isConnected()) {
+      NODELET_WARN("Unable to connect, retrying.");
+      ros::WallDuration(1).sleep();
+      continue;
+    }
+
+    NODELET_DEBUG("Logging in to laser.");
+    laser.login();
+    cfg = laser.getScanCfg();
+    outputRange = laser.getScanOutputRange();
+
+    if (cfg.scaningFrequency != 5000) {
+      laser.disconnect();
+      NODELET_WARN("Unable to get laser output range. Retrying.");
+      ros::WallDuration(1).sleep();
+      continue;
+    }
+
+    NODELET_INFO("Connected to laser.");
+
+    NODELET_DEBUG("Laser configuration: scaningFrequency %d, angleResolution %d, startAngle %d, stopAngle %d",
+                  cfg.scaningFrequency, cfg.angleResolution, cfg.startAngle,
+                  cfg.stopAngle);
+    NODELET_DEBUG(
+        "Laser output range:angleResolution %d, startAngle %d, stopAngle %d",
+        outputRange.angleResolution, outputRange.startAngle,
+        outputRange.stopAngle);
+
+    sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
+    
+    scan_msg->header.frame_id = frame_id;
+    scan_msg->range_min = 0.01;
+    scan_msg->range_max = 20.0;
+    scan_msg->scan_time = 100.0 / cfg.scaningFrequency;
+    scan_msg->angle_increment =
+        static_cast<double>(outputRange.angleResolution / 10000.0 * DEG2RAD);
+    scan_msg->angle_min = static_cast<double>(
+        outputRange.startAngle / 10000.0 * DEG2RAD - M_PI / 2);
+    scan_msg->angle_max = static_cast<double>(
+        outputRange.stopAngle / 10000.0 * DEG2RAD - M_PI / 2);
+
+    NODELET_DEBUG_STREAM("Device resolution is "
+                         << (double)outputRange.angleResolution / 10000.0
+                         << " degrees.");
+    NODELET_DEBUG_STREAM("Device frequency is "
+                         << (double)cfg.scaningFrequency / 100.0 << " Hz");
+
+    int angle_range = outputRange.stopAngle - outputRange.startAngle;
+    int num_values = angle_range / outputRange.angleResolution;
+    if (angle_range % outputRange.angleResolution == 0) {
+      // Include endpoint
+      ++num_values;
+    }
+    scan_msg->ranges.resize(num_values);
+    scan_msg->intensities.resize(num_values);
+
+    scan_msg->time_increment = (outputRange.angleResolution / 10000.0) / 360.0 /
+                              (cfg.scaningFrequency / 100.0);
+
+    NODELET_DEBUG_STREAM("Time increment is "
+                         << static_cast<int>(scan_msg->time_increment * 1000000)
+                         << " microseconds");
+
+    dataCfg.outputChannel = 1;
+    dataCfg.remission = true;
+    dataCfg.resolution = 1;
+    dataCfg.encoder = 0;
+    dataCfg.position = false;
+    dataCfg.deviceName = false;
+    dataCfg.outputInterval = 1;
+
+    NODELET_DEBUG("Setting scan data configuration.");
+    laser.setScanDataCfg(dataCfg);
+
+    NODELET_DEBUG("Starting measurements.");
+    laser.startMeas();
+
+    NODELET_DEBUG("Waiting for ready status.");
+    ros::Time ready_status_timeout = ros::Time::now() + ros::Duration(5);
+
+    // while(1)
+    // {
+    status_t stat = laser.queryStatus();
+    ros::WallDuration(1.0).sleep();
+    if (stat != ready_for_measurement) {
+      NODELET_WARN("Laser not ready. Retrying initialization.");
+      laser.disconnect();
+      ros::WallDuration(1).sleep();
+      continue;
+    }
+    /*if (stat == ready_for_measurement)
+    {
+      NODELET_DEBUG("Ready status achieved.");
+      break;
+    }
+
+      if (ros::Time::now() > ready_status_timeout)
+      {
+        NODELET_WARN("Timed out waiting for ready status. Trying again.");
+        laser.disconnect();
+        continue;
+      }
+
+      if (!ros::ok())
+      {
+        laser.disconnect();
+        return 1;
+      }
+    }*/
+
+    NODELET_DEBUG("Starting device.");
+    laser.startDevice(); // Log out to properly re-enable system after config
+
+    NODELET_DEBUG("Commanding continuous measurements.");
+    laser.scanContinous(1);
+
+    while (this->ok()) {
+      ros::Time start = ros::Time::now();
+
+      scan_msg->header.stamp = start;
+      ++scan_msg->header.seq;
+
+      scanData data;
+      NODELET_DEBUG("Reading scan data.");
+      if (laser.getScanData(&data)) {
+        for (int i = 0; i < data.dist_len1; i++) {
+          float range_data = data.dist1[i] * 0.001;
+
+          if (inf_range && range_data < scan_msg->range_min) {
+            scan_msg->ranges[i] = std::numeric_limits<float>::infinity();
+          } else {
+            scan_msg->ranges[i] = range_data;
+          }
+        }
+
+        for (int i = 0; i < data.rssi_len1; i++) {
+          scan_msg->intensities[i] = data.rssi1[i];
+        }
+
+        NODELET_DEBUG("Publishing scan data.");
+        scan_pub.publish(scan_msg);
+      } else {
+        NODELET_ERROR(
+            "Laser timed out on delivering scan, attempting to reinitialize.");
+        break;
+      }
+    }
+
+    laser.scanContinous(0);
+    laser.stopMeas();
+    laser.disconnect();
+  }
+}
+
+LMS1xxNodelet::~LMS1xxNodelet() {
+  this->isShuttingDown;
+  this->thread.join();
+}
+
+}
+
+PLUGINLIB_EXPORT_CLASS(lms1xx::LMS1xxNodelet, nodelet::Nodelet)


### PR DESCRIPTION
If you like this version, the node version can be substituted by calling the nodelet, so that the code isn't duplicated (like here: https://www.clearpathrobotics.com/assets/guides/ros/Nodelet%20Everything.html#and-now-code ).